### PR TITLE
Update to redeemDelegations Interface

### DIFF
--- a/ERCS/erc-7710.md
+++ b/ERCS/erc-7710.md
@@ -53,7 +53,7 @@ RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as de
 - A **Delegator** is a smart contract that can create a delegation. It implements the `ERC7710` interface, which
   implements ERC-1271.
 - A **Delegation Manager** is a singleton smart contract that is responsible for validating delegation authority and
-  calling on the *Delegator* to execute an action. It implements the `ER7710Manager` interface.
+  calling on the *Delegator* to execute an action. It implements the `ERC7710Manager` interface.
 - A **delegation** is an authority given to another address to perform a specific action.
 - A **delegate** is a smart contract, smart contract account, or EOA that has authority to redeem a delegation.
 - A **redeemer** is a *delegate* that is using a delegation.
@@ -62,14 +62,14 @@ RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as de
 
 #### Redeeming a Delegation
 
-When a delegate wishes to redeem a delegation, they call the `redeemDelegation` function on the Delegation Manager and
-pass in the Action they want to execute and the proof of authority (ie delegation) which they are executing on behalf
+When a delegate wishes to redeem a delegation, they call the `redeemDelegations` function on the Delegation Manager and
+pass in the action they want to execute and the proof of authority (ie delegation) which they are executing on behalf
 of. The Delegation Manager then verifies the delegation's validity and, if valid, calls the privileged function on the
 Delegator which executes the specified capability on behalf of the Delegator.
 
 ```mermaid
 flowchart LR
-    redeemer(["redeemer"]) --"redeemDelegation"--> Delegation_Manager(["Delegation Manager"])
+    redeemer(["redeemer"]) --"redeemDelegations"--> Delegation_Manager(["Delegation Manager"])
     Delegation_Manager -.->|validate delegation w/ Action| Delegation_Manager
     Delegation_Manager --"execute delegated action"--> Delegator(["Delegator"])
     Delegator --"executes CALL using Action"--> Target(["Target"])
@@ -83,39 +83,31 @@ flowchart LR
 
 #### `ERC7710Manager.sol`
 
-The Delegation Manager MUST implement the `redeemDelegation` which will be responsible for validating the delegation
-being invoked, and will then call the delegator to execute the action.
+The Delegation Manager MUST implement the `redeemDelegations` which will be responsible for validating the delegations
+being redeemed, and will then call the delegators to execute the actions.
 
-The bytes `_authority` passed in as a parameter to the `redeemDelegation` function contains the authority to execute a
+The bytes array `_permissionContexts` passed in as a parameter to the `redeemDelegations` function contains the authority to execute a
 specific action on behalf of the delegating contract.
 
-The `Action` struct has two fields: `mode` and `executionCalldata`, which are defined precisely as in [ERC-7579](./eip-7579.md) (under the "Execution Behavior" section).  Briefly, `mode` encodes the "behavior" of the execution, which could be a single call, a batch call, a delegatecall, and others.  `executionCallData` encodes the data of the execution, which typically includes at least a `target`, a `value`, and a `to` address.
+The bytes32 array `_modes` and the bytes array `_executionCallDatas` passed in as parameters to the `redeemDelegations` function are arrays of `mode` and `executionCalldata`, which are defined precisely in [ERC-7579](./eip-7579.md) (under the "Execution Behavior" section).  Briefly, `mode` encodes the "behavior" of the execution, which could be a single call, a batch call, and others.  `executionCallData` encodes the data of the execution, which typically includes at least a `target`, a `value`, and a `to` address.
 
 ```solidity
 pragma solidity 0.8.23;
 
 /**
- * @title Action
- * @notice This struct represents an action to be taken.
- * @dev `mode` and `executionCalldata` are as defined in ERC-7579.
- */
-struct Action {
-    bytes32 mode;
-    bytes executionCalldata;
-}
-
-/**
  * @title ERC7710Manager
- * @notice Interface for Delegation Manager that exposes the redeemDelegation function.
+ * @notice Interface for Delegation Manager that exposes the redeemDelegations function.
  */
 interface ERC7710Manager {
     /**
-     * @notice This method validates the provided data and executes the action if the caller has authority to do so.
-     * @dev the structure of the _authority bytes is determined by the specific Delegation Manager implementation
-     * @param _authority the data used to validate the authority given to execute the action.
+     * @notice This method validates the provided permission contexts and executes the execution if the caller has authority to do so.
+     * @dev the structure of the _permissionContexts bytes[] is determined by the specific Delegation Manager implementation
+     * @param _permissionContexts the data used to validate the authority given to execute the corresponding execution.
      * @param _action the action to be executed
+     * @param _modes the array of modes to execute the related executioncallData
+     * @param _executionCallDatas the array of encoded executions to be executed
      */
-    function redeemDelegation(bytes calldata _authority, Action calldata _action) external;
+    function redeemDelegations(bytes[] calldata _permissionContexts, bytes32[] calldata _modes, bytes[] calldata _executionCallDatas) external;
 }
 ```
 
@@ -157,7 +149,7 @@ That approach had a few downsides:
 
 To solve the first issue, we decided to remove the requirement for the delegator to implement any specific interface.
 Rather, we rely on the Delegation Manager to correctly call the delegator, and we rely on the fact that a delegator would
-only create `_authority` for a Delegation Manager that knows how to correctly call it.
+only create `_permissionContexts` for a Delegation Manager that knows how to correctly call it.
 
 To solve the second issue, we decied to adopt the execution interface from ERC-7579, which had to solve a similar problem
 within the context of modular smart accounts: defining a standardized execution interface that can support many types of


### PR DESCRIPTION
## Why
- update `redeemDelegation` params to array, allowing for multiple delegation redemptions in one call
- removes unnecessary Action struct
- updates `redeemDelegation` to more proper plural to `redeemDelegations`
